### PR TITLE
添加一个命令行添加认证token的方法

### DIFF
--- a/lib/alias.js
+++ b/lib/alias.js
@@ -56,6 +56,7 @@ var alias = {}
     
     , set: 'config set'
     , get: 'config get'
+    , auth: 'authorize'
   }
   ;
 

--- a/lib/cli_core.js
+++ b/lib/cli_core.js
@@ -92,9 +92,16 @@ var cmdMap = {
     return apiExc(apiStr, apiQs);
   }
   , authorize: function(){
-    console.log(tips.auth, color(getAccessTokenUrl()).green);
-    open(getAccessTokenUrl());
-    takeAccessToken();
+    if(arguments.length > 0) {
+      var text = arguments[0];
+	  var conf = new (require('./config').Config)(confPath);
+      log('a new access token: ' + text);
+      conf.set('tsina.access_token', text);
+      conf.save();
+    } else {
+      console.log(tips.auth, color(getAccessTokenUrl()).green);
+      open(getAccessTokenUrl());
+    }
   }
   , completion: function(){
     var tab = require('tabtab');


### PR DESCRIPTION
·process.stdin.on·在cygwin环境下不work（node.js装Windows原声版，在cygwin下运行），原来交互式输入token的办法行不通。

由于其他命令在认证失败的时候会自动·takeAccessToken(callback)·，所以·twei authorize·可以腾出来，用于在命令行传入token。

加了一条alias，现在可以：

```
twei auth <token>
```

另外不带参数的·twei auth·仍然跳到认证网页。
